### PR TITLE
Fixes for Api's

### DIFF
--- a/haasomeapi/apis/CustomBotApi.py
+++ b/haasomeapi/apis/CustomBotApi.py
@@ -744,7 +744,8 @@ class CustomBotApi(ApiBase):
                               fee: float, baseprice: float,  priceSpreadType: EnumFlashSpreadOptions, pricespread: float,
                               percentageboost: float, minpercentage: float, maxpercentage: float, amounttype: EnumCurrencyType,
                               amountspread: float, buyamount: float, sellamount: float, refilldelay: int, safetyenabled: bool,
-                              safetytriggerlevel: float, safetymoveinout: bool, followthetrend: bool, followthetrendchannelrange: int,
+                              safetytriggerlevel: float, safetymovein: bool,
+                              safetymoveout: bool, followthetrend: bool, followthetrendchannelrange: int,
                               followthetrendchanneloffset: int, followthetrendtimeout: int):
         """ Modify a Flash Crash bot
 
@@ -776,6 +777,8 @@ class CustomBotApi(ApiBase):
         :returns: :class:`~haasomeapi.dataobjects.util.HaasomeClientResponse`
         :returns: In .result :class:`~haasomeapi.dataobjects.custombots.FlashCrashBot`: Flash Crash bot object
         """
+        # if priceSpreadType = 0:
+            
 
         response = super()._execute_request("/SetupFlashCrashBot",  {"botGuid": botguid,
                                                                      "botName": botname,
@@ -796,7 +799,8 @@ class CustomBotApi(ApiBase):
                                                                      "refillDelay": refilldelay,
                                                                      "safetyEnabled": str(safetyenabled).lower(),
                                                                      "safetyTriggerLevel": safetytriggerlevel,
-                                                                     "safetyMoveInOut": str(safetymoveinout).lower(),
+                                                                     "safetyMoveOut": str(safetymoveout),
+                                                                     "safetyMoveIn":str(safetymovein),
                                                                      "fttEnabled": str(followthetrend).lower(),
                                                                      "fttRange": followthetrendchannelrange,
                                                                      "fttOffset": followthetrendchanneloffset,
@@ -926,6 +930,9 @@ class CustomBotApi(ApiBase):
             return HaasomeClientResponse(EnumErrorCode(int(response["ErrorCode"])),
                                          response["ErrorMessage"], {})
 
+    
+
+    
     def setup_mad_hatter_bot(self, botName: str, botGuid: str, accountGuid: str, primaryCoin: str, secondaryCoin: str, contractName: str, leverage: str, templateGuid: str, position: str, fee: float, tradeAmountType:  EnumBotTradeAmount, tradeAmount: float, useconsensus:bool, disableAfterStopLoss: bool,
                              interval: int, includeIncompleteInterval: bool, mappedBuySignal: EnumFundPosition, mappedSellSignal: EnumFundPosition):
         """ Modify Mad Hatter bot
@@ -946,6 +953,8 @@ class CustomBotApi(ApiBase):
         :param disableAfterStopLoss: bool: Disable bot after stop loss
         :param interval: int: Price Ticker Minute Interval. Ex. 1,2,3,,5,15,30, etc
         :param includeIncompleteInterval: bool: Allow a incomplete price ticker
+        :param mappedBuySignal: str: mappedBuySignal
+        :param mappedSellSignal: str: mappedSellSignal
 
         :returns: :class:`~haasomeapi.dataobjects.util.HaasomeClientResponse`
         :returns: In .result :class:`~haasomeapi.dataobjects.custombots.MadHatterBot`: Mad Hatter bot object
@@ -977,7 +986,7 @@ class CustomBotApi(ApiBase):
         except:
             return HaasomeClientResponse(EnumErrorCode(int(response["ErrorCode"])),
                                          response["ErrorMessage"], {})
-
+    
     def setup_order_bot(self, accountguid: str, botguid: str, botname: str, primarycoin: str, secondarycoin: str):
         """ Modify Order bot
 
@@ -1602,8 +1611,7 @@ class CustomBotApi(ApiBase):
     def rebalance_advanced_index_bot_index(self, botguid: str):
         """ Rebalance a advanced index bot
         :param botguid: str: Custom bot guid
-     
-     
+    
         :returns: :class:`~haasomeapi.dataobjects.util.HaasomeClientResponse`
         :returns: In .result :class:`~haasomeapi.dataobjects.custombots.AdvancedIndexBot`: Crypto Index bot object 
         """

--- a/haasomeapi/apis/TradeBotApi.py
+++ b/haasomeapi/apis/TradeBotApi.py
@@ -54,6 +54,9 @@ class TradeBotApi(ApiBase):
             indicator.indicatorInterface = indicatoroptions
             indicators[k] = indicator
 
+
+
+
         for k, v in botinitial.safeties.items():
             safetyoptions = []
             safety = super()._from_json(v, Safety)
@@ -287,7 +290,7 @@ class TradeBotApi(ApiBase):
                                          response["ErrorMessage"], {})
 
     def setup_trade_bot(self, accountguid: str, botguid: str, botname: str, primarycoin: str, secondarycoin: str,
-                        contractname: str, leverage: float, groupid: str, useconsensus: bool, copymarketstoelements: bool):
+                        contractname: str, leverage: float, groupid: str, useconsensus: bool, buyweight, sellweight,longweight,shortweight, exitweight,copymarketstoelements: bool):
         """ Modify a trade bot
 
         :param accountguid: str: Account guid
@@ -305,7 +308,7 @@ class TradeBotApi(ApiBase):
         :returns: In .result :class:`~haasomeapi.dataobjects.tradebot.TradeBot`: Trade bot object
         """
 
-        response = super()._execute_request("/SetupSpotBotTradeAmount",  {"botGuid": botguid,
+        response = super()._execute_request("/SetupTradeBot",  {"botGuid": botguid,
                                                                           "botName": botname,
                                                                           "accountGuid": accountguid,
                                                                           "primaryCoin": primarycoin,
@@ -314,6 +317,11 @@ class TradeBotApi(ApiBase):
                                                                           "leverage": float(str(leverage).replace(',', '.')),
                                                                           "groupId": groupid,
                                                                           "useConsensus": str(useconsensus).lower(),
+                                                                          "buyWeight": buyweight,
+                                                                          "sellWeight": sellweight,
+                                                                          "longWeight": longweight,
+                                                                          "shortWeight": shortweight,
+                                                                          "exitWeight": exitweight,
                                                                           "copyMarketToElements": str(copymarketstoelements).lower()})
         try:
             return HaasomeClientResponse(EnumErrorCode(int(response["ErrorCode"])),
@@ -449,7 +457,7 @@ class TradeBotApi(ApiBase):
         """
 
         response = super()._execute_request("/AddIndicator",  {"botGuid": botguid,
-                                                               "indicatorType": EnumSafety(indicatortype).name.capitalize()})
+                                                               "indicatorType": EnumIndicator(indicatortype).name}) #removed .capitalize() from the name tag
 
         try:
             return HaasomeClientResponse(EnumErrorCode(int(response["ErrorCode"])),

--- a/haasomeapi/enums/EnumIndicator.py
+++ b/haasomeapi/enums/EnumIndicator.py
@@ -1,83 +1,67 @@
 from enum import Enum
 
 class EnumIndicator(Enum):
-    AROON = 0
-    AROON_OSCILLATOR = 1
-    AWESOME_OSCILLATOR = 2
-
-    BLIND = 3
+  
+    Aroon = 0
+    AroonOscillator = 1
+    AwesomeOscillator = 2
+    Blind = 3
     BOP = 4
-    BBANDS = 5
-    BBANDSB = 6
-    BBANDSW = 7
-    BUY_LOW_SELL_HIGH_FIXED = 8
-    BUY_LOW_SELL_HIGH_DYNAMIC = 9
-    BBANDS_PSHAI = 51
-
+    BBands = 5
+    BBandsB = 6
+    BBandsW = 7
+    BuyLowSellHighFixed = 8
+    BuyLowSellHighDynamic = 9
+    BBandsPshai = 51
     CCI = 11
     CMO = 12
-    COPPOCK_CURVE = 13
+    CoppockCurve = 13
     CRSI = 14
-    CANDLE_PATTERN = 15
-
+    CandlePattern = 15
     DEMA = 16
-    DEMA_NEW = 52
-    DONCHIAN_CHANNELS = 17
+    DEMA_New = 52
+    DonchianChannels = 17
     DPO = 18
-
     EMA = 19
-    EMA_NEW = 53
-    ELLIOT = 20
-
-    FASTRSI = 21
-    FIBONACCI = 22
-    FRACTIAL = 23
-
-    ICHIMOKU_CLOUDS = 24
-
-    JOHNS_CANDELIER = 25
-
-    KELTNER_CHANNELS = 26
+    EMA_New = 53
+    Elliot = 20
+    FastRSI = 21
+    Fibonacci = 22
+    Fractial = 23
+    IchimokuClouds = 24
+    KeltnerChannels = 26
     KAMA = 27
-    KAMA_NEW = 54
-    KELTNERCHANNELS_NEW = 55
-
+    KAMA_New = 54
+    KeltnerChannels_New = 55
     MACD = 28
-    MACD_NEW = 69
+    MACD_New = 69
     MFI = 29
-    MOMENTUM = 70
-
+    Momentum = 70
     ROC = 30
-    ROCALT = 31
+    ROCAlt = 31
     RSI = 32
-    RSI_NEW = 59
-    REGRESSION_SLOBE = 33
-
+    RSI_New = 59
+    RegressionSlobe = 33
     SAR = 34
-    SLOWRSI = 35
+    SlowRSI = 35
     SMA = 36
-    STOCHRSI = 37
-    STOCHRSI_NEW = 62
-    STOCHASTIC = 38
-    STOCHASTIC2 = 39
-    SMALL_FRACTIAL = 40
-    SCRIPT_INDICATOR = 41
-
+    StochRSI = 37
+    StochRSI_New = 62
+    Stochastic = 38
+    Stochastic2 = 39
+    SmallFractial = 40
+    ScriptIndicator = 41
     TEMA = 42
-    TEMA_NEW = 63
+    TEMA_New = 63
     TRIX = 43
-    TRIX_NEW = 64
+    TRIX_New = 64
     TRIMA = 44
-    TRIMA_NEW = 65
+    TRIMA_New = 65
     TD = 71
-    TELEGRAM_INDICATOR = 45
-    TIMED_BLIND = 49
-
-    ULTIMATE_OSCILLATOR = 46
-    ULTIMATE_OSCILLATOR_NEW = 66
-
+    TimedBlind = 49
+    UltimateOscillator = 46
+    UltimateOscillator_New = 66
     WMA = 47
-    WILLIAMSW = 48
-    WILLIAMSR_NEW = 67
+    WilliamsW = 48
+    WilliamsR_New = 67
 
-    HAAS_SCRIPT_INDICATOR = 50


### PR DESCRIPTION
Custom Bot Api :
setup_flas_crash_bot - removed savetymoveinout, added instead two variables: safetymovein, safetymoveout.
TradeBotApi :
setup_trade_bot - added several params that weren't existent in the config
changed /request from setupSpotBotTradeAmmount to /SetupTradeBot
add_indicator - removed capitalize from response
EnumIndicators - replaced content with correct one.